### PR TITLE
Remove python3.7 support as EOL is 27.06.2023

### DIFF
--- a/jobScrapper_base/Dockerfile
+++ b/jobScrapper_base/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get -qq update > /dev/null && apt-get -qq install -y --no-install-recomm
 RUN add-apt-repository ppa:deadsnakes/ppa > /dev/null
 
 RUN apt-get -qq update > /dev/null && apt-get -qq install -y --no-install-recommends \
-    python3.7 \
-    python3.7-venv \
     python3.8 \
     python3.8-venv \
     python3.9 \
@@ -31,8 +29,7 @@ RUN apt-get -qq update > /dev/null && apt-get -qq install -y --no-install-recomm
     rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.7 && \
-    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8 && \
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8 && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11


### PR DESCRIPTION
![image](https://github.com/wkobiela/jobScrapper/assets/12174429/f8dcb085-df96-43f4-8f57-dbb9d15324f0)
![image](https://github.com/wkobiela/jobScrapper/assets/12174429/5ef84c7d-88ed-4e5c-a78b-469855dce51c)
https://devguide.python.org/versions/